### PR TITLE
Fix SonarQube High severity issues: string duplication and cognitive complexity

### DIFF
--- a/cmd/mcpcurl/main.go
+++ b/cmd/mcpcurl/main.go
@@ -174,30 +174,40 @@ func main() {
 		_, _ = fmt.Fprintf(os.Stderr, "Error getting pretty flag: %v\n", err)
 		os.Exit(1)
 	}
-	// Get server command
+
+	// Get server command and load schema
 	serverCmd, err := rootCmd.Flags().GetString("stdio-server-cmd")
 	if err == nil && serverCmd != "" {
-		// Fetch schema from server
-		jsonRequest, err := buildJSONRPCRequest("tools/list", "", nil)
-		if err == nil {
-			response, err := executeServerCommand(serverCmd, jsonRequest)
-			if err == nil {
-				// Parse the schema response
-				var schemaResp SchemaResponse
-				if err := json.Unmarshal([]byte(response), &schemaResp); err == nil {
-					// Add all the generated commands as subcommands of tools
-					for _, tool := range schemaResp.Result.Tools {
-						addCommandFromTool(toolsCmd, &tool, prettyPrint)
-					}
-				}
-			}
-		}
+		loadSchemaAndRegisterTools(serverCmd, prettyPrint)
 	}
 
 	// Execute
 	if err := rootCmd.Execute(); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Error executing command: %v\n", err)
 		os.Exit(1)
+	}
+}
+
+// loadSchemaAndRegisterTools fetches the schema from the server and registers tool commands
+func loadSchemaAndRegisterTools(serverCmd string, prettyPrint bool) {
+	jsonRequest, err := buildJSONRPCRequest("tools/list", "", nil)
+	if err != nil {
+		return
+	}
+
+	response, err := executeServerCommand(serverCmd, jsonRequest)
+	if err != nil {
+		return
+	}
+
+	var schemaResp SchemaResponse
+	if err := json.Unmarshal([]byte(response), &schemaResp); err != nil {
+		return
+	}
+
+	// Add all the generated commands as subcommands of tools
+	for _, tool := range schemaResp.Result.Tools {
+		addCommandFromTool(toolsCmd, &tool, prettyPrint)
 	}
 }
 

--- a/pkg/github/search.go
+++ b/pkg/github/search.go
@@ -13,6 +13,11 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
+const (
+	errMsgReadResponseBody = "failed to read response body: %w"
+	errMsgMarshalResponse  = "failed to marshal response: %w"
+)
+
 // SearchRepositories creates a tool to search for GitHub repositories.
 func SearchRepositories(getClient GetClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("search_repositories",
@@ -61,14 +66,14 @@ func SearchRepositories(getClient GetClientFn, t translations.TranslationHelperF
 			if resp.StatusCode != 200 {
 				body, err := io.ReadAll(resp.Body)
 				if err != nil {
-					return nil, fmt.Errorf("failed to read response body: %w", err)
+					return nil, fmt.Errorf(errMsgReadResponseBody, err)
 				}
 				return mcp.NewToolResultError(fmt.Sprintf("failed to search repositories: %s", string(body))), nil
 			}
 
 			r, err := json.Marshal(result)
 			if err != nil {
-				return nil, fmt.Errorf("failed to marshal response: %w", err)
+				return nil, fmt.Errorf(errMsgMarshalResponse, err)
 			}
 
 			return mcp.NewToolResultText(string(r)), nil
@@ -141,14 +146,14 @@ func SearchCode(getClient GetClientFn, t translations.TranslationHelperFunc) (to
 			if resp.StatusCode != 200 {
 				body, err := io.ReadAll(resp.Body)
 				if err != nil {
-					return nil, fmt.Errorf("failed to read response body: %w", err)
+					return nil, fmt.Errorf(errMsgReadResponseBody, err)
 				}
 				return mcp.NewToolResultError(fmt.Sprintf("failed to search code: %s", string(body))), nil
 			}
 
 			r, err := json.Marshal(result)
 			if err != nil {
-				return nil, fmt.Errorf("failed to marshal response: %w", err)
+				return nil, fmt.Errorf(errMsgMarshalResponse, err)
 			}
 
 			return mcp.NewToolResultText(string(r)), nil
@@ -215,7 +220,7 @@ func userOrOrgHandler(accountType string, getClient GetClientFn) server.ToolHand
 		if resp.StatusCode != 200 {
 			body, err := io.ReadAll(resp.Body)
 			if err != nil {
-				return nil, fmt.Errorf("failed to read response body: %w", err)
+				return nil, fmt.Errorf(errMsgReadResponseBody, err)
 			}
 			return mcp.NewToolResultError(fmt.Sprintf("failed to search %ss: %s", accountType, string(body))), nil
 		}
@@ -251,7 +256,7 @@ func userOrOrgHandler(accountType string, getClient GetClientFn) server.ToolHand
 
 		r, err := json.Marshal(minimalResp)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal response: %w", err)
+			return nil, fmt.Errorf(errMsgMarshalResponse, err)
 		}
 		return mcp.NewToolResultText(string(r)), nil
 	}


### PR DESCRIPTION
## Summary

This PR addresses two High severity SonarQube code quality issues:

1. **String literal duplication (go:S1192)** in `pkg/github/search.go`: Defined constants for error message format strings that were duplicated 3 times each
2. **Cognitive complexity (go:S3776)** in `cmd/mcpcurl/main.go`: Reduced the cognitive complexity of the `main()` function from 18 to below the 15 threshold by extracting schema loading logic into a separate function

## Changes

### pkg/github/search.go
- Added constants `errMsgReadResponseBody` and `errMsgMarshalResponse` to eliminate string duplication
- Replaced 6 total occurrences of duplicated error format strings with the constants
- No behavioral changes, purely refactoring for maintainability

### cmd/mcpcurl/main.go  
- Extracted `loadSchemaAndRegisterTools()` function to reduce cognitive complexity
- Moved nested conditional logic for schema fetching and tool registration out of `main()`
- Maintained identical error handling behavior (silent returns on errors)

## Testing
- ✅ Lint checks pass (`./script/lint`)
- ✅ Test suite passes (`./script/test`)
- ⚠️ Note: `cmd/mcpcurl` has no automated test coverage, so manual verification is recommended

## Review Focus

**Critical areas to review:**
1. **Error handling in `loadSchemaAndRegisterTools()`**: Verify that the early returns maintain the same silent error handling behavior as the original nested `if err == nil` checks
2. **Behavioral equivalence**: Confirm the refactored code has identical behavior to the original - the schema loading and tool registration should work exactly the same way
3. **Manual testing**: Since mcpcurl has no automated tests, manual CLI testing is recommended to ensure the tool still works correctly

## Tradeoffs

- **Silent error handling**: The original code (and this refactor) silently ignores errors during schema loading. This behavior is maintained for consistency, but reviewers may want to consider whether errors should be logged or surfaced to users in a future change.

---

Link to Devin run: https://app.devin.ai/sessions/aa1880c7d8e6463d87b8fd3eb740167e

Requested by: Shawn Azman (@ShawnAzman)