### PR TITLE
Fix SonarQube issues: string duplication and cognitive complexity

### DIFF
--- a/cmd/mcpcurl/main.go
+++ b/cmd/mcpcurl/main.go
@@ -94,6 +94,10 @@ type (
 	}
 )
 
+const (
+	stdioServerCmdFlag = "stdio-server-cmd"
+)
+
 var (
 	// Create root command
 	rootCmd = &cobra.Command{
@@ -107,7 +111,7 @@ var (
 			}
 
 			// Check if the required global flag is provided
-			serverCmd, _ := cmd.Flags().GetString("stdio-server-cmd")
+			serverCmd, _ := cmd.Flags().GetString(stdioServerCmdFlag)
 			if serverCmd == "" {
 				return fmt.Errorf("--stdio-server-cmd is required")
 			}
@@ -121,7 +125,7 @@ var (
 		Short: "Fetch schema from MCP server",
 		Long:  "Fetches the tools schema from the MCP server specified by --stdio-server-cmd",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			serverCmd, _ := cmd.Flags().GetString("stdio-server-cmd")
+			serverCmd, _ := cmd.Flags().GetString(stdioServerCmdFlag)
 			if serverCmd == "" {
 				return fmt.Errorf("--stdio-server-cmd is required")
 			}
@@ -156,8 +160,8 @@ func main() {
 	rootCmd.AddCommand(schemaCmd)
 
 	// Add global flag for stdio server command
-	rootCmd.PersistentFlags().String("stdio-server-cmd", "", "Shell command to invoke MCP server via stdio (required)")
-	_ = rootCmd.MarkPersistentFlagRequired("stdio-server-cmd")
+	rootCmd.PersistentFlags().String(stdioServerCmdFlag, "", "Shell command to invoke MCP server via stdio (required)")
+	_ = rootCmd.MarkPersistentFlagRequired(stdioServerCmdFlag)
 
 	// Add global flag for pretty printing
 	rootCmd.PersistentFlags().Bool("pretty", true, "Pretty print MCP response (only for JSON or JSONL responses)")
@@ -175,29 +179,36 @@ func main() {
 		os.Exit(1)
 	}
 	// Get server command
-	serverCmd, err := rootCmd.Flags().GetString("stdio-server-cmd")
+	serverCmd, err := rootCmd.Flags().GetString(stdioServerCmdFlag)
 	if err == nil && serverCmd != "" {
-		// Fetch schema from server
-		jsonRequest, err := buildJSONRPCRequest("tools/list", "", nil)
-		if err == nil {
-			response, err := executeServerCommand(serverCmd, jsonRequest)
-			if err == nil {
-				// Parse the schema response
-				var schemaResp SchemaResponse
-				if err := json.Unmarshal([]byte(response), &schemaResp); err == nil {
-					// Add all the generated commands as subcommands of tools
-					for _, tool := range schemaResp.Result.Tools {
-						addCommandFromTool(toolsCmd, &tool, prettyPrint)
-					}
-				}
-			}
-		}
+		loadAndRegisterTools(serverCmd, prettyPrint)
 	}
 
 	// Execute
 	if err := rootCmd.Execute(); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Error executing command: %v\n", err)
 		os.Exit(1)
+	}
+}
+
+func loadAndRegisterTools(serverCmd string, prettyPrint bool) {
+	jsonRequest, err := buildJSONRPCRequest("tools/list", "", nil)
+	if err != nil {
+		return
+	}
+
+	response, err := executeServerCommand(serverCmd, jsonRequest)
+	if err != nil {
+		return
+	}
+
+	var schemaResp SchemaResponse
+	if err := json.Unmarshal([]byte(response), &schemaResp); err != nil {
+		return
+	}
+
+	for _, tool := range schemaResp.Result.Tools {
+		addCommandFromTool(toolsCmd, &tool, prettyPrint)
 	}
 }
 
@@ -222,7 +233,7 @@ func addCommandFromTool(toolsCmd *cobra.Command, tool *Tool, prettyPrint bool) {
 			}
 
 			// Execute the server command
-			serverCmd, err := cmd.Flags().GetString("stdio-server-cmd")
+			serverCmd, err := cmd.Flags().GetString(stdioServerCmdFlag)
 			if err != nil {
 				_, _ = fmt.Fprintf(os.Stderr, "failed to get stdio-server-cmd: %v\n", err)
 				return


### PR DESCRIPTION
## Summary

This PR addresses two High severity SonarQube code quality issues in `cmd/mcpcurl/main.go`:

1. **String Literal Duplication (go:S1192)**: Extracted the repeated string literal `"stdio-server-cmd"` into a constant `stdioServerCmdFlag` and replaced all 6 occurrences throughout the file.

2. **Cognitive Complexity (go:S3776)**: Refactored the `main()` function to reduce cognitive complexity from 18 to 15 by extracting the nested schema loading logic into a new helper function `loadAndRegisterTools()`.

## Changes

- Added `stdioServerCmdFlag` constant for the flag name
- Replaced 6 hardcoded string literals with the constant
- Extracted schema loading logic from `main()` into `loadAndRegisterTools()` helper function
- Preserved existing error handling behavior (silent failures on schema loading errors)

## Testing

- ✅ Lint checks pass (`./script/lint`)
- ✅ All existing tests pass (`./script/test`)
- ⚠️ Note: `cmd/mcpcurl` has no test files, so changes are verified only through integration with other packages

## Review Focus

1. **Error Handling**: Verify that the refactored `loadAndRegisterTools()` function maintains the same error handling behavior as the original inline code (errors are silently ignored, which appears intentional for optional schema loading)

2. **Constant Usage**: Confirm all occurrences of `"stdio-server-cmd"` string literal have been replaced with the constant (6 total replacements)

3. **Behavioral Equivalence**: The refactoring should be functionally identical to the original code - just reorganized for better maintainability

---

**Link to Devin run**: https://app.devin.ai/sessions/5205158dc4a747aa823b21de087c67fd  
**Requested by**: Shawn Azman (@ShawnAzman)

Closes: N/A (code quality improvement)