### PR TITLE
fix: resolve SonarQube S1192 and S3776 issues in pkg/github/notifications.go

### DIFF
--- a/pkg/github/notifications.go
+++ b/pkg/github/notifications.go
@@ -22,6 +22,14 @@ const (
 	FilterOnlyParticipating = "only_participating"
 )
 
+const (
+	errGetGitHubClient    = "failed to get GitHub client: %w"
+	errReadResponseBody   = "failed to read response body: %w"
+	errMarshalResponse    = "failed to marshal response: %w"
+	paramNotificationID   = "notificationID"
+	descNotificationsTime = "RFC3339/ISO8601"
+)
+
 // ListNotifications creates a tool to list notifications for the current user.
 func ListNotifications(getClient GetClientFn, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("list_notifications",
@@ -51,70 +59,24 @@ func ListNotifications(getClient GetClientFn, t translations.TranslationHelperFu
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			client, err := getClient(ctx)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
+				return nil, fmt.Errorf(errGetGitHubClient, err)
 			}
 
-			filter, err := OptionalParam[string](request, "filter")
-			if err != nil {
-				return mcp.NewToolResultError(err.Error()), nil
+			params, errResult, err := parseListNotificationsParams(request)
+			if errResult != nil || err != nil {
+				return errResult, err
 			}
 
-			since, err := OptionalParam[string](request, "since")
-			if err != nil {
-				return mcp.NewToolResultError(err.Error()), nil
-			}
-
-			before, err := OptionalParam[string](request, "before")
-			if err != nil {
-				return mcp.NewToolResultError(err.Error()), nil
-			}
-
-			owner, err := OptionalParam[string](request, "owner")
-			if err != nil {
-				return mcp.NewToolResultError(err.Error()), nil
-			}
-			repo, err := OptionalParam[string](request, "repo")
-			if err != nil {
-				return mcp.NewToolResultError(err.Error()), nil
-			}
-
-			paginationParams, err := OptionalPaginationParams(request)
-			if err != nil {
-				return mcp.NewToolResultError(err.Error()), nil
-			}
-
-			// Build options
-			opts := &github.NotificationListOptions{
-				All:           filter == FilterIncludeRead,
-				Participating: filter == FilterOnlyParticipating,
-				ListOptions: github.ListOptions{
-					Page:    paginationParams.page,
-					PerPage: paginationParams.perPage,
-				},
-			}
-
-			// Parse time parameters if provided
-			if since != "" {
-				sinceTime, err := time.Parse(time.RFC3339, since)
-				if err != nil {
-					return mcp.NewToolResultError(fmt.Sprintf("invalid since time format, should be RFC3339/ISO8601: %v", err)), nil
-				}
-				opts.Since = sinceTime
-			}
-
-			if before != "" {
-				beforeTime, err := time.Parse(time.RFC3339, before)
-				if err != nil {
-					return mcp.NewToolResultError(fmt.Sprintf("invalid before time format, should be RFC3339/ISO8601: %v", err)), nil
-				}
-				opts.Before = beforeTime
+			opts, errResult := buildNotificationListOptions(params)
+			if errResult != nil {
+				return errResult, nil
 			}
 
 			var notifications []*github.Notification
 			var resp *github.Response
 
-			if owner != "" && repo != "" {
-				notifications, resp, err = client.Activity.ListRepositoryNotifications(ctx, owner, repo, opts)
+			if params.owner != "" && params.repo != "" {
+				notifications, resp, err = client.Activity.ListRepositoryNotifications(ctx, params.owner, params.repo, opts)
 			} else {
 				notifications, resp, err = client.Activity.ListNotifications(ctx, opts)
 			}
@@ -130,7 +92,7 @@ func ListNotifications(getClient GetClientFn, t translations.TranslationHelperFu
 			if resp.StatusCode != http.StatusOK {
 				body, err := io.ReadAll(resp.Body)
 				if err != nil {
-					return nil, fmt.Errorf("failed to read response body: %w", err)
+					return nil, fmt.Errorf(errReadResponseBody, err)
 				}
 				return mcp.NewToolResultError(fmt.Sprintf("failed to get notifications: %s", string(body))), nil
 			}
@@ -138,11 +100,82 @@ func ListNotifications(getClient GetClientFn, t translations.TranslationHelperFu
 			// Marshal response to JSON
 			r, err := json.Marshal(notifications)
 			if err != nil {
-				return nil, fmt.Errorf("failed to marshal response: %w", err)
+				return nil, fmt.Errorf(errMarshalResponse, err)
 			}
 
 			return mcp.NewToolResultText(string(r)), nil
 		}
+}
+
+// listNotificationsParams holds the parsed parameters for the list_notifications tool.
+type listNotificationsParams struct {
+	filter     string
+	since      string
+	before     string
+	owner      string
+	repo       string
+	pagination PaginationParams
+}
+
+// parseListNotificationsParams extracts the parameters for the list_notifications tool from the request.
+func parseListNotificationsParams(request mcp.CallToolRequest) (*listNotificationsParams, *mcp.CallToolResult, error) {
+	params := &listNotificationsParams{}
+
+	stringFields := []struct {
+		name string
+		dest *string
+	}{
+		{"filter", &params.filter},
+		{"since", &params.since},
+		{"before", &params.before},
+		{"owner", &params.owner},
+		{"repo", &params.repo},
+	}
+	for _, field := range stringFields {
+		value, err := OptionalParam[string](request, field.name)
+		if err != nil {
+			return nil, mcp.NewToolResultError(err.Error()), nil
+		}
+		*field.dest = value
+	}
+
+	pagination, err := OptionalPaginationParams(request)
+	if err != nil {
+		return nil, mcp.NewToolResultError(err.Error()), nil
+	}
+	params.pagination = pagination
+
+	return params, nil, nil
+}
+
+// buildNotificationListOptions builds the GitHub API options from parsed parameters.
+func buildNotificationListOptions(params *listNotificationsParams) (*github.NotificationListOptions, *mcp.CallToolResult) {
+	opts := &github.NotificationListOptions{
+		All:           params.filter == FilterIncludeRead,
+		Participating: params.filter == FilterOnlyParticipating,
+		ListOptions: github.ListOptions{
+			Page:    params.pagination.page,
+			PerPage: params.pagination.perPage,
+		},
+	}
+
+	if params.since != "" {
+		sinceTime, err := time.Parse(time.RFC3339, params.since)
+		if err != nil {
+			return nil, mcp.NewToolResultError(fmt.Sprintf("invalid since time format, should be %s: %v", descNotificationsTime, err))
+		}
+		opts.Since = sinceTime
+	}
+
+	if params.before != "" {
+		beforeTime, err := time.Parse(time.RFC3339, params.before)
+		if err != nil {
+			return nil, mcp.NewToolResultError(fmt.Sprintf("invalid before time format, should be %s: %v", descNotificationsTime, err))
+		}
+		opts.Before = beforeTime
+	}
+
+	return opts, nil
 }
 
 // DismissNotification creates a tool to mark a notification as read/done.
@@ -162,7 +195,7 @@ func DismissNotification(getclient GetClientFn, t translations.TranslationHelper
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			client, err := getclient(ctx)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
+				return nil, fmt.Errorf(errGetGitHubClient, err)
 			}
 
 			threadID, err := RequiredParam[string](request, "threadID")
@@ -203,7 +236,7 @@ func DismissNotification(getclient GetClientFn, t translations.TranslationHelper
 			if resp.StatusCode != http.StatusResetContent && resp.StatusCode != http.StatusOK {
 				body, err := io.ReadAll(resp.Body)
 				if err != nil {
-					return nil, fmt.Errorf("failed to read response body: %w", err)
+					return nil, fmt.Errorf(errReadResponseBody, err)
 				}
 				return mcp.NewToolResultError(fmt.Sprintf("failed to mark notification as %s: %s", state, string(body))), nil
 			}
@@ -233,7 +266,7 @@ func MarkAllNotificationsRead(getClient GetClientFn, t translations.TranslationH
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			client, err := getClient(ctx)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
+				return nil, fmt.Errorf(errGetGitHubClient, err)
 			}
 
 			lastReadAt, err := OptionalParam[string](request, "lastReadAt")
@@ -282,7 +315,7 @@ func MarkAllNotificationsRead(getClient GetClientFn, t translations.TranslationH
 			if resp.StatusCode != http.StatusResetContent && resp.StatusCode != http.StatusOK {
 				body, err := io.ReadAll(resp.Body)
 				if err != nil {
-					return nil, fmt.Errorf("failed to read response body: %w", err)
+					return nil, fmt.Errorf(errReadResponseBody, err)
 				}
 				return mcp.NewToolResultError(fmt.Sprintf("failed to mark all notifications as read: %s", string(body))), nil
 			}
@@ -299,7 +332,7 @@ func GetNotificationDetails(getClient GetClientFn, t translations.TranslationHel
 				Title:        t("TOOL_GET_NOTIFICATION_DETAILS_USER_TITLE", "Get notification details"),
 				ReadOnlyHint: ToBoolPtr(true),
 			}),
-			mcp.WithString("notificationID",
+			mcp.WithString(paramNotificationID,
 				mcp.Required(),
 				mcp.Description("The ID of the notification"),
 			),
@@ -307,10 +340,10 @@ func GetNotificationDetails(getClient GetClientFn, t translations.TranslationHel
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			client, err := getClient(ctx)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
+				return nil, fmt.Errorf(errGetGitHubClient, err)
 			}
 
-			notificationID, err := RequiredParam[string](request, "notificationID")
+			notificationID, err := RequiredParam[string](request, paramNotificationID)
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
@@ -328,14 +361,14 @@ func GetNotificationDetails(getClient GetClientFn, t translations.TranslationHel
 			if resp.StatusCode != http.StatusOK {
 				body, err := io.ReadAll(resp.Body)
 				if err != nil {
-					return nil, fmt.Errorf("failed to read response body: %w", err)
+					return nil, fmt.Errorf(errReadResponseBody, err)
 				}
 				return mcp.NewToolResultError(fmt.Sprintf("failed to get notification details: %s", string(body))), nil
 			}
 
 			r, err := json.Marshal(thread)
 			if err != nil {
-				return nil, fmt.Errorf("failed to marshal response: %w", err)
+				return nil, fmt.Errorf(errMarshalResponse, err)
 			}
 
 			return mcp.NewToolResultText(string(r)), nil
@@ -357,7 +390,7 @@ func ManageNotificationSubscription(getClient GetClientFn, t translations.Transl
 				Title:        t("TOOL_MANAGE_NOTIFICATION_SUBSCRIPTION_USER_TITLE", "Manage notification subscription"),
 				ReadOnlyHint: ToBoolPtr(false),
 			}),
-			mcp.WithString("notificationID",
+			mcp.WithString(paramNotificationID,
 				mcp.Required(),
 				mcp.Description("The ID of the notification thread."),
 			),
@@ -370,10 +403,10 @@ func ManageNotificationSubscription(getClient GetClientFn, t translations.Transl
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			client, err := getClient(ctx)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
+				return nil, fmt.Errorf(errGetGitHubClient, err)
 			}
 
-			notificationID, err := RequiredParam[string](request, "notificationID")
+			notificationID, err := RequiredParam[string](request, paramNotificationID)
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
@@ -422,7 +455,7 @@ func ManageNotificationSubscription(getClient GetClientFn, t translations.Transl
 
 			r, err := json.Marshal(result)
 			if err != nil {
-				return nil, fmt.Errorf("failed to marshal response: %w", err)
+				return nil, fmt.Errorf(errMarshalResponse, err)
 			}
 			return mcp.NewToolResultText(string(r)), nil
 		}
@@ -459,7 +492,7 @@ func ManageRepositoryNotificationSubscription(getClient GetClientFn, t translati
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			client, err := getClient(ctx)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get GitHub client: %w", err)
+				return nil, fmt.Errorf(errGetGitHubClient, err)
 			}
 
 			owner, err := RequiredParam[string](request, "owner")
@@ -518,7 +551,7 @@ func ManageRepositoryNotificationSubscription(getClient GetClientFn, t translati
 
 			r, err := json.Marshal(result)
 			if err != nil {
-				return nil, fmt.Errorf("failed to marshal response: %w", err)
+				return nil, fmt.Errorf(errMarshalResponse, err)
 			}
 			return mcp.NewToolResultText(string(r)), nil
 		}


### PR DESCRIPTION
Closes: N/A (SonarQube high-severity cleanup)

## Summary
Fixes 8 high-severity SonarQube issues in `pkg/github/notifications.go`:

**S1192 (duplicated string literals)** — added package-level constants:
- `errGetGitHubClient` for `"failed to get GitHub client: %w"`
- `errReadResponseBody` for `"failed to read response body: %w"`
- `errMarshalResponse` for `"failed to marshal response: %w"`
- `paramNotificationID` for `"notificationID"`
- `descNotificationsTime` for `"RFC3339/ISO8601"`

**S3776 (cognitive complexity)** — refactored the `ListNotifications` handler by extracting two helpers:
- `parseListNotificationsParams(request)` — table-driven extraction of the optional string params + pagination into a `listNotificationsParams` struct
- `buildNotificationListOptions(params)` — builds `github.NotificationListOptions` and validates `since`/`before` RFC3339 timestamps

No behavioral changes; all error messages and responses are identical.

## Testing
- `go build ./...`, `go vet ./pkg/github/`, `gofmt -l` — clean
- `go test ./pkg/github/` — all tests pass

Link to Devin session: https://app.devin.ai/sessions/247a7e4688344a7d9fef9dd3856db04f
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`0646a31`](https://github.com/cog-gtm/github-mcp-server/pull/149/commits/0646a312c4bc32f10f0b74e48571c590a05fb564) |

<a href="https://staging.itsdev.in/review/cog-gtm/github-mcp-server/pull/149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->