### PR TITLE
Bump Go toolchain to 1.25.11 to resolve std-lib security vulnerabilities

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version-file: "go.mod"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1
+          version: v2.5.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           go-version-file: "go.mod"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           version: v2.5.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.4-alpine AS build
+FROM golang:1.25.11-alpine AS build
 ARG VERSION="dev"
 
 # Set the working directory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/github/github-mcp-server
 
-go 1.23.7
+go 1.25.11
 
 require (
 	github.com/google/go-github/v72 v72.0.0


### PR DESCRIPTION
<!-- Closes: N/A (Snyk SCA remediation) -->

## Summary

A Snyk SCA scan flagged the Go **standard library** (built at `go 1.23.7`) with **10 HIGH-severity** vulnerabilities. These are fixed by building against a patched Go toolchain. This PR bumps the `go` directive — and the matching CI/Docker Go pins — to **1.25.11**, the smallest stable patch that clears every reported HIGH.

```
go.mod   go 1.23.7  -> go 1.25.11
Dockerfile  golang:1.24.4-alpine -> golang:1.25.11-alpine
```

### Why 1.25.11 (not 1.24.x or latest 1.26.x)
The 1.24 line is EOL for these CVEs — `std/mime`, `std/net`, `std/net/http` fixes were **not** backported, so 1.24.x cannot clear all HIGHs. 1.25.11 is the lowest patch where every reported HIGH is fixed (per the Snyk fix versions below), so it's the smallest viable bump.

### HIGHs resolved (all in the Go std lib)
| Package | Issue | Snyk fix version (1.25 line) |
|---|---|---|
| `std/crypto/x509` | Uncaught Exception + 3× resource exhaustion | 1.25.2 / 1.25.3 / 1.25.9 / **1.25.11** |
| `std/mime` | Resource exhaustion | **1.25.11** |
| `std/net` | Double free; Uncaught Exception | 1.25.10 |
| `std/net/http` | Sensitive info exposure; Infinite loop | 1.24.4 / 1.25.10 |
| `std/net/url` | Resource exhaustion | 1.24.12 |

### CI / lint change
golangci-lint **v2.1** is built with go1.24 and hard-fails to load any module whose language version is ≥ 1.25 (`config load error`, not findings). So `.github/workflows/lint.yml` is updated to:
- `golangci-lint` `v2.1` → `v2.5.0` (built with go1.25, supports the 1.25 language version)
- setup-go `go-version: stable` → `go-version-file: "go.mod"`, matching every other workflow so the lint job tracks go.mod.

The other workflows (`go.yml`, `license-check.yml`, `docs-check.yml`, `goreleaser.yml`) already use `go-version-file: "go.mod"`, and `code-scanning.yml` resolves the version from the environment, so they pick up 1.25.11 automatically. No Dockerfile multi-stage or distroless runtime change needed beyond the build image.

## Verification
Local, with the go1.25.11 toolchain:
- `go build ./...` — pass
- `go test ./...` — pass
- `golangci-lint run` (v2.5.0) — `0 issues`

Snyk `npx snyk test --all-projects` (`go.mod` std-lib version drives the std findings):

| | HIGH | Medium | Low | Total issues | Vulnerable paths |
|---|---|---|---|---|---|
| Before (`go 1.23.7`) | **10** | 15 | 1 | 26 | 161 |
| After (`go 1.25.11`) | **0** | 1 | 0 | 1 | 2 |

All 10 std-lib HIGHs are resolved. The single remaining Medium is in the third-party dependency `github.com/go-viper/mapstructure/v2` (log-injection) — unrelated to the Go toolchain and out of scope for this change.

## Tradeoffs
- No `go.sum` changes (module graph pruning is identical for ≥1.17 modules).
- Pinned golangci-lint to an exact `v2.5.0` rather than latest (`v2.12.x`); newer golangci-lint adds new gosec/staticcheck/govet rules that would surface unrelated findings, so the oldest go1.25-compatible release keeps this PR focused on the security bump.

Link to Devin session: https://app.devin.ai/sessions/737542c0b74f418cb2042a646f39a83b
Requested by: @shayanshafii
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/github-mcp-server/pull/153?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/github-mcp-server/pull/153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/github-mcp-server/pull/153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->